### PR TITLE
correcao de bugs no schema e specimen da funcao download

### DIFF
--- a/common/models/schema.js
+++ b/common/models/schema.js
@@ -289,10 +289,12 @@ module.exports = function(Schema) {
   };
 
 
-  function downloadImage(queue){
+ function downloadImage(queue){
     var i = 0;
     var end = queue.length;
-    var erro = "";
+    var erro = [];
+    var count = 0;
+    var countErr = 0;
     async.whilst(function(){
       return i < end;
     }, function(callback){
@@ -301,34 +303,49 @@ module.exports = function(Schema) {
       var resized = queue[i].resized; //local da imagem salva
       var thumbnail = queue[i].thumbnail; //local da imagem salva
       var file = __dirname + "/../../client"+local; //arquivo da imagem salva
+      var file2 = __dirname + "/../../client"+thumbnail;
       console.log(i + " of "+end+" images");
       fs.exists(file, function(exists){
         // check if exist localy
         if (exists) {
-          console.log("image alreadly exists");
-          i++;
-          callback();
-
+          fs.exists(file2, function(exists){
+            if(exists){
+              console.log("image alreadly exists");
+              i++;
+              callback();              
+            }else{
+              fs.unlink(file);
+              callback();
+            }
+          });
         } else {
-
           console.log("making request to " + original);
-
-          requestFile(original,local, function test (){
-                var count = 0;  
-                var readChunk = require('read-chunk'); // npm install read-chunk 
+          async.series([
+            function fileRequest(callback){
+              if(count < 3){
+                requestFile(original,local,callback);
+              }
+            },
+            function test(callback){
+                var readChunk = require('read-chunk'); // npm install read-chunk
                 var imageType = require('image-type');
                 var buffer = readChunk.sync(__dirname + "/../../client"+local, 0, 120);
 
                 console.log(imageType(buffer));
                 //Checar se a imagem salva é um arquivo jpeg, caso não seja requisitar o endereço da imagem novamente
                 if (imageType(buffer)==null){
-                        console.log("Arquivo inválido");
-                        while (count < 3){
-                            requestFile(original,local,callback);
-                            count++;
-                        }
+                        console.log("Arquivo inválido");                
+                        count++; 
+                        if(count == 3){
+                          erro[countErr] = "Ocorreu um erro na URL: " + original;
+                          countErr++;
+                          count = 0;
+                          i++;
+                        } 
+                        callback();   
+                      
                 }else{
-                    console.log("Arquivo válido"); 
+                    console.log("Arquivo válido");
                     async.parallel([
                       function resizedConverting(callback) {
                           // write resized
@@ -340,13 +357,14 @@ module.exports = function(Schema) {
                       },
                       ],function done() {
                            i++;
+                           count = 0;
                            callback();
-                            
-                      }); 
-                             
+                      });
                 }
-
-        });
+          },
+          ],function done(){
+            callback();
+          });
 
         }
 
@@ -354,7 +372,9 @@ module.exports = function(Schema) {
 
     }, function(err){
       if (err) throw new Error(err);
-      console.log(erro);
+      for(var t=0;t < countErr;t++){
+        console.log(erro[t]);
+      }
       console.log("done.");
     });
   }


### PR DESCRIPTION
Devido no lado do cliente ocorrer um erro de não identificar o caminho da miniatura de uma imagem. Acabei identificando um bug no tratamento da url de download da imagem. Antes quando uma imagem não era baixada no formato certo, o algoritmo ao invés de requisitar pelo menos 3 vezes o download da imagem, só requisitava uma e na próxima url era que a requisição era feita três vezes. 